### PR TITLE
IAS RTD Module: allow iasRtdProvider to store fetched data

### DIFF
--- a/modules/iasRtdProvider.js
+++ b/modules/iasRtdProvider.js
@@ -5,6 +5,10 @@ import {getGlobal} from '../src/prebidGlobal.js';
 import {getAdUnitSizes} from '../libraries/sizeUtils/sizeUtils.js';
 import {getGptSlotInfoForAdUnitCode} from '../libraries/gptUtils/gptUtils.js';
 
+/**
+ * @typedef {import('../modules/rtdModule/index.js').RtdSubmodule} RtdSubmodule
+ */
+
 /** @type {string} */
 const MODULE_NAME = 'realTimeData';
 const SUBMODULE_NAME = 'ias';
@@ -161,15 +165,15 @@ function parseResponse(result) {
 }
 
 function mergeResponseData(iasResponse) {
-  const prevSlots = iasTargeting[SLOTS_OBJECT_FIELD_NAME] || {};
+  const cachedSlots = iasTargeting[SLOTS_OBJECT_FIELD_NAME] || {};
 
   iasTargeting = iasResponse;
 
-  const slots = iasResponse[SLOTS_OBJECT_FIELD_NAME] || {};
+  const slots = iasTargeting[SLOTS_OBJECT_FIELD_NAME] || {};
 
-  Object.keys(prevSlots)
+  Object.keys(cachedSlots)
     .filter((adUnit) => adUnit in slots === false)
-    .forEach((adUnit) => (slots[adUnit] = prevSlots[adUnit]));
+    .forEach((adUnit) => (slots[adUnit] = cachedSlots[adUnit]));
 }
 
 function getTargetingData(adUnits, config, userConsent) {

--- a/modules/iasRtdProvider.js
+++ b/modules/iasRtdProvider.js
@@ -153,13 +153,23 @@ function constructQueryString(anId, adUnits, pageUrl, adUnitPath) {
 }
 
 function parseResponse(result) {
-  let iasResponse = {};
   try {
-    iasResponse = JSON.parse(result);
+    mergeResponseData(JSON.parse(result));
   } catch (err) {
     utils.logError('error', err);
   }
+}
+
+function mergeResponseData(iasResponse) {
+  const prevSlots = iasTargeting[SLOTS_OBJECT_FIELD_NAME] || {};
+
   iasTargeting = iasResponse;
+
+  const slots = iasResponse[SLOTS_OBJECT_FIELD_NAME] || {};
+
+  Object.keys(prevSlots)
+    .filter((adUnit) => adUnit in slots === false)
+    .forEach((adUnit) => (slots[adUnit] = prevSlots[adUnit]));
 }
 
 function getTargetingData(adUnits, config, userConsent) {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Bugfix

## Description of change

Modify the adapter implementation to retain previously parsed slot-level data. Each time the getBidRequestData method is invoked, it should merge the IAS response data with the existing cached slot-level data from the internal data store. If a request is made multiple times for the same slot, the data from the latest response will replace the existing cached data for that slot.

## Other information

Fixes issue: https://github.com/prebid/Prebid.js/issues/13004